### PR TITLE
Add ability to run commands

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+#https://EditorConfig.org
+# top-most EditorConfig file
+root=true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,0 +1,36 @@
+---
+CommitMsg:
+  HardTabs:
+    enabled: true
+PreCommit:
+  RuboCop:
+    enabled: true
+    on_warn: fail
+  BundleAudit:
+    enabled: true
+  BundleCheck:
+    enabled: true
+  BundleOutdated:
+    enabled: true
+  ExecutePermissions:
+    enabled: true
+    exclude:
+      - bin/*
+  ForbiddenBranches:
+    enabled: true
+    branch_patterns: master
+  HardTabs:
+    enabled: true
+  JsonSyntax:
+    enabled: true
+  LineEndings:
+    enabled: true
+    eol: "\n"
+  Mdl:
+    enabled: true
+  TrailingWhitespace:
+    enabled: true
+  YamlLint:
+    enabled: true
+  YamlSyntax:
+    enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## Version 0.7.0
+
 - Add ability to run commands at the end
 - Add bump, editorconfig and overcommit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add ability to run commands at the end
+- Add bump, editorconfig and overcommit
+
 ## Version 0.6.0
 
 - First public release

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ All templates are directly configured as Gem file, so you can build them,
 install them and even publish them to your own private Gem repository or
 rubygems.org.
 
+### Final commands
+
+If you want commands to be executed after scaffolding your project, add them as
+a list under the `finalize` key of the YAML
+
 ## Configuration
 
 Ashiba YAML configuration files reside in ~/.ashibarc or in /etc/ashiba/ashibarc.

--- a/Rakefile
+++ b/Rakefile
@@ -16,3 +16,17 @@ task :gem => :build
 Dir["tasks/*.rake"].each do |taskfile|
   load taskfile
 end
+
+namespace :lint do
+  desc 'Linting for all markdown files'
+  task :markdown do
+    require 'mdl'
+
+    MarkdownLint.run(%w[--verbose README.md CHANGELOG.md])
+  end
+end
+
+require 'bump/tasks'
+%w[set pre file current].each { |task| Rake::Task["bump:#{task}"].clear }
+Bump.changelog = :editor
+Bump.tag_by_default = true

--- a/TODO.md
+++ b/TODO.md
@@ -3,3 +3,4 @@
 - Clean up structure to more OOP fashion
 - Template inheritance (needs refactoring first, e.g for ashiba-template)
 - Move to `chef-raketasks`
+- Support variables in `finalize` commands

--- a/ashiba.gemspec
+++ b/ashiba.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_development_dependency "bump", "~> 0.9"
   spec.add_development_dependency 'mdl', '~> 0.4'
   spec.add_development_dependency 'rspec', '~> 3.7'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.18'

--- a/lib/ashiba/cli.rb
+++ b/lib/ashiba/cli.rb
@@ -150,6 +150,14 @@ module Ashiba
         entries.each do |name|
           template("#{template_base}/#{name}", "#{path}/#{dest_filename(name)}")
         end
+
+        template_info = get_data_from_template(template)
+        finalize = Array(template_info['finalize'])
+        return unless finalize
+
+        Dir.chdir(path) do
+          finalize.each { |cmd| puts `#{cmd}` }
+        end
       end
 
       # rubocop:disable Style/MethodMissingSuper,Style/MissingRespondToMissing

--- a/lib/ashiba/version.rb
+++ b/lib/ashiba/version.rb
@@ -1,3 +1,3 @@
 module Ashiba
-  VERSION = '0.6.0'.freeze
+  VERSION = '0.7.0'.freeze
 end

--- a/templates/ashiba-template.yaml
+++ b/templates/ashiba-template.yaml
@@ -13,3 +13,5 @@ variables:
   summary: Summary of the template
   description: A longer explanation of its functionality
   url: http://example.com
+finalize:
+  - git init .


### PR DESCRIPTION
New projects often need some initialization steps. Now you can add those as a list under the `finalize` keyword in template metadata.